### PR TITLE
Theta refactor:

### DIFF
--- a/theta/sqlx/theta_sketch_a_not_b.sqlx
+++ b/theta/sqlx/theta_sketch_a_not_b.sqlx
@@ -28,7 +28,7 @@ OPTIONS (
 Param sketchA: the first sketch "A" as bytes.
 Param sketchB: the second sketch "B" as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns a Compact, Compressed Theta Sketch, as bytes, from which the set difference cardinality can be obtained.
+Returns: a Compact, Compressed Theta Sketch, as bytes, from which the set difference cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_a_not_b.sqlx
+++ b/theta/sqlx/theta_sketch_a_not_b.sqlx
@@ -1,28 +1,32 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_a_not_b(sketch1 BYTES, sketch2 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, seed INT64)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
-  description = '''Computes a sketch that represents the scalar set difference: sketch1 and not sketch2.
-Param sketch1: the first sketch "a" as bytes.
-Param sketch2: the second sketch "b" as bytes.
+  description = '''Computes a sketch that represents the scalar set difference: sketchA and not sketchB.
+Param sketchA: the first sketch "A" as bytes.
+Param sketchB: the second sketch "B" as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
 Returns a Compact, Compressed Theta Sketch, as bytes, from which the set difference cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
@@ -31,7 +35,7 @@ const default_seed = BigInt(9001);
 try {
   var a_not_b = new Module.theta_a_not_b(seed ? BigInt(seed) : default_seed);
   try {
-    return a_not_b.computeWithB64ReturnB64Compressed(sketch1, sketch2, seed ? BigInt(seed) : default_seed);
+    return a_not_b.computeWithB64ReturnB64Compressed(sketchA, sketchB, seed ? BigInt(seed) : default_seed);
   } finally {
     a_not_b.delete();
   }

--- a/theta/sqlx/theta_sketch_agg_string.sqlx
+++ b/theta/sqlx/theta_sketch_agg_string.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE AGGREGATE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_agg_string(str STRING, params STRUCT<lg_k INT, seed INT64> NOT AGGREGATE)
+config { hasOutput: true }
+
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(str STRING, params STRUCT<lg_k BYTEINT, seed INT64> NOT AGGREGATE)
 RETURNS BYTES 
 LANGUAGE js
 OPTIONS (

--- a/theta/sqlx/theta_sketch_agg_string.sqlx
+++ b/theta/sqlx/theta_sketch_agg_string.sqlx
@@ -28,7 +28,7 @@ OPTIONS (
 Param str: the STRING column of identifiers.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: the seed to be used by the underlying hash function.
-Returns a Compact, Compressed Theta Sketch, as bytes, from which the cardinality can be obtained. 
+Returns: a Compact, Compressed Theta Sketch, as bytes, from which the cardinality can be obtained. 
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 import ModuleFactory from "$GCS_BUCKET/theta_sketch.mjs";

--- a/theta/sqlx/theta_sketch_agg_union.sqlx
+++ b/theta/sqlx/theta_sketch_agg_union.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE AGGREGATE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_agg_union(sketch BYTES, params STRUCT<lg_k INT, seed INT64> NOT AGGREGATE)
+config { hasOutput: true }
+
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(sketch BYTES, params STRUCT<lg_k BYTEINT, seed INT64> NOT AGGREGATE)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (

--- a/theta/sqlx/theta_sketch_agg_union.sqlx
+++ b/theta/sqlx/theta_sketch_agg_union.sqlx
@@ -28,7 +28,7 @@ OPTIONS (
 Param sketch: the column of sketches. Each as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
+Returns: a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 import ModuleFactory from "$GCS_BUCKET/theta_sketch.mjs";

--- a/theta/sqlx/theta_sketch_get_estimate.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate.sqlx
@@ -1,34 +1,38 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_get_estimate(base64 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, seed INT64)
 RETURNS FLOAT64
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
   description = '''Gets cardinality estimate and bounds from given sketch.
-Param base64: The given sketch to query as bytes.
+Param sketch: The given sketch to query as bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
 Returns a FLOAT64 value as the cardinality estimate.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.compact_theta_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.compact_theta_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return sketch.getEstimate();
   } finally {

--- a/theta/sqlx/theta_sketch_get_estimate.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate.sqlx
@@ -27,7 +27,7 @@ OPTIONS (
   description = '''Gets cardinality estimate and bounds from given sketch.
 Param sketch: The given sketch to query as bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
-Returns a FLOAT64 value as the cardinality estimate.
+Returns: a FLOAT64 value as the cardinality estimate.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
@@ -30,7 +30,7 @@ Param num_std_devs: The returned bounds will be based on the statistical confide
 from the returned estimate. This number may be one of {1,2,3}, where 1 represents 68% confidence, 2 represents 95% confidence and 3 represents 99.7% confidence.
 For example, if the given num_std_devs = 2 and the returned values are {1000, 990, 1010} that means that with 95% confidence, the true value lies within the range [990, 1010].
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
-Returns an array of 3 FLOAT64 values as {estimate, lowerBound, upperBound}.
+Returns: an array of 3 FLOAT64 values as {estimate, lowerBound, upperBound}.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
@@ -1,27 +1,31 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_get_estimate_and_bounds(base64 BYTES, num_std_devs INT, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, num_std_devs BYTEINT, seed INT64)
 RETURNS ARRAY<FLOAT64>
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
   description = '''Gets cardinality estimate and bounds from given sketch.
-Param base64: The given sketch to query as bytes.
+Param sketch: The given sketch to query as bytes.
 Param num_std_devs: The returned bounds will be based on the statistical confidence interval determined by the given number of standard deviations
 from the returned estimate. This number may be one of {1,2,3}, where 1 represents 68% confidence, 2 represents 95% confidence and 3 represents 99.7% confidence.
 For example, if the given num_std_devs = 2 and the returned values are {1000, 990, 1010} that means that with 95% confidence, the true value lies within the range [990, 1010].
@@ -31,7 +35,7 @@ For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramewor
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.compact_theta_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.compact_theta_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return [sketch.getEstimate(), sketch.getLowerBound(num_std_devs), sketch.getUpperBound(num_std_devs)];
   } finally {

--- a/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
+++ b/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
@@ -31,7 +31,7 @@ A Jaccard of .95 means the overlap between the two sets is 95% of the union of t
 Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns an array of 3 floating-point values {LowerBound, Estimate, UpperBound} of the Jaccard index.
+Returns: an array of 3 floating-point values {LowerBound, Estimate, UpperBound} of the Jaccard index.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
+++ b/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION ${self()}(sketch1 BYTES, sketch2 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, seed INT64)
 RETURNS ARRAY<FLOAT64>
 LANGUAGE js
 OPTIONS (
@@ -24,15 +28,15 @@ OPTIONS (
 J(A,B) = (A ^ B)/(A U B) is used to measure how similar the two sketches are to each other.
 If J = 1.0, the sketches are considered equal. If J = 0, the two sketches are disjoint.
 A Jaccard of .95 means the overlap between the two sets is 95% of the union of the two sets.
-Param sketch1: the first sketch as bytes.
-Param sketch2: the second sketch as bytes.
+Param sketchA: the first sketch as bytes.
+Param sketchB: the second sketch as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
 Returns an array of 3 floating-point values {LowerBound, Estimate, UpperBound} of the Jaccard index.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  const jaccard = Module.thetaJaccardSimilarity(sketch1, sketch2, seed == null ? default_seed : BigInt(seed));
+  const jaccard = Module.thetaJaccardSimilarity(sketchA, sketchB, seed == null ? default_seed : BigInt(seed));
   return [jaccard.get(0), jaccard.get(1), jaccard.get(2)];
 } catch (e) {
   throw new Error(Module.getExceptionMessage(e));

--- a/theta/sqlx/theta_sketch_scalar_intersection.sqlx
+++ b/theta/sqlx/theta_sketch_scalar_intersection.sqlx
@@ -1,28 +1,32 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_scalar_intersection(sketchBytes1 BYTES, sketchBytes2 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, seed INT64)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
   description = '''Computes a sketch that represents the scalar intersection of the two given sketches.
-Param sketchBytes1: the first sketch as bytes.
-Param sketchBytes2: the second sketch as bytes.
+Param sketchA: the first sketch as bytes.
+Param sketchB: the second sketch as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
 Returns a Compact, Compressed Theta Sketch, as bytes, from which the intersection cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
@@ -31,8 +35,8 @@ const default_seed = BigInt(9001);
 try {
   var intersection = new Module.theta_intersection(seed ? BigInt(seed) : default_seed);
   try {
-    intersection.updateWithB64(sketchBytes1, seed ? BigInt(seed) : default_seed);
-    intersection.updateWithB64(sketchBytes2, seed ? BigInt(seed) : default_seed);
+    intersection.updateWithB64(sketchA, seed ? BigInt(seed) : default_seed);
+    intersection.updateWithB64(sketchB, seed ? BigInt(seed) : default_seed);
     return intersection.getResultB64Compressed();
   } finally {
     intersection.delete();

--- a/theta/sqlx/theta_sketch_scalar_intersection.sqlx
+++ b/theta/sqlx/theta_sketch_scalar_intersection.sqlx
@@ -28,7 +28,7 @@ OPTIONS (
 Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns a Compact, Compressed Theta Sketch, as bytes, from which the intersection cardinality can be obtained.
+Returns: a Compact, Compressed Theta Sketch, as bytes, from which the intersection cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_scalar_union.sqlx
+++ b/theta/sqlx/theta_sketch_scalar_union.sqlx
@@ -29,7 +29,7 @@ Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
+Returns: a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_lg_k = 12;

--- a/theta/sqlx/theta_sketch_scalar_union.sqlx
+++ b/theta/sqlx/theta_sketch_scalar_union.sqlx
@@ -1,28 +1,32 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_scalar_union(sketch1 BYTES, sketch2 BYTES, lg_k INT64, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, lg_k BYTEINT, seed INT64)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
   description = '''Computes a sketch that represents the scalar union of the two given sketches.
-Param sketch1: the first sketch as bytes.
-Param sketch2: the second sketch as bytes.
+Param sketchA: the first sketch as bytes.
+Param sketchB: the second sketch as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
 Returns a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
@@ -33,8 +37,8 @@ const default_seed = BigInt(9001);
 try {
   var union = new Module.theta_union(lg_k ? lg_k : default_lg_k, seed ? BigInt(seed) : default_seed);
   try {
-    union.updateWithB64(sketch1, seed ? BigInt(seed) : default_seed)
-    union.updateWithB64(sketch2, seed ? BigInt(seed) : default_seed)
+    union.updateWithB64(sketchA, seed ? BigInt(seed) : default_seed)
+    union.updateWithB64(sketchB, seed ? BigInt(seed) : default_seed)
     return union.getResultB64Compressed();
   } finally {
     union.delete();

--- a/theta/sqlx/theta_sketch_to_string.sqlx
+++ b/theta/sqlx/theta_sketch_to_string.sqlx
@@ -27,7 +27,7 @@ OPTIONS (
   description = '''Returns a summary string that represents the state of the given sketch.
 Param sketch: the given sketch as bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
-Returns a string that represents the state of the given sketch.
+Returns: a string that represents the state of the given sketch.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);

--- a/theta/sqlx/theta_sketch_to_string.sqlx
+++ b/theta/sqlx/theta_sketch_to_string.sqlx
@@ -1,34 +1,38 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.theta_sketch_to_string(base64 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, seed INT64)
 RETURNS STRING
 LANGUAGE js
 OPTIONS (
   library=["$GCS_BUCKET/theta_sketch.js"],
   description = '''Returns a summary string that represents the state of the given sketch.
-Param base64 the given sketch as base64 encoded bytes.
+Param sketch: the given sketch as bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
 Returns a string that represents the state of the given sketch.
 For more details: https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.compact_theta_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.compact_theta_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return sketch.toString();
   } finally {


### PR DESCRIPTION
Reformatted the license header.

Added config { hasOutput: true }

Used ${self()} substitution.

Renamed input parameters to be more meaningful.

For low-valued integer parameters like lg_k and num_std_dev use BYTEINT.