### PR TITLE
KLL refactor:

### DIFF
--- a/kll/sqlx/kll_sketch_float_build.sqlx
+++ b/kll/sqlx/kll_sketch_float_build.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(value FLOAT64, k INT NOT AGGREGATE)
 RETURNS BYTES
@@ -23,7 +27,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the distribution of the given column.
 Param value: the column of values.
 Param k: the sketch accuracy/size parameter as an integer in the range [8, 65535].
-Returns a KLL Sketch, as bytes.
+Returns: a KLL Sketch, as bytes.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 import ModuleFactory from "gs://$GCS_BUCKET/kll_sketch.mjs";

--- a/kll/sqlx/kll_sketch_float_get_cdf.sqlx
+++ b/kll/sqlx/kll_sketch_float_get_cdf.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, split_points ARRAY<FLOAT64>, inclusive BOOL)
 RETURNS ARRAY<FLOAT64>
@@ -29,7 +33,7 @@ Param inclusive: if true the rank of a value includes its own weight,
 and therefore if the sketch contains values equal to a slit point,
 then in CDF such values are included into the interval to the left of split point.
 Otherwise they are included into the interval to the right of split point.
-Returns an array of M+1 values which are a consecutive approximation to the CDF
+Returns: an array of M+1 values which are a consecutive approximation to the CDF
 of the input stream given the split_points. The value at array position j of the returned
 CDF array is the sum of the returned values in positions 0 through j of the PMF array.
 This can be viewed as array of ranks of the given split points plus one more value that is always 1.

--- a/kll/sqlx/kll_sketch_float_get_n.sqlx
+++ b/kll/sqlx/kll_sketch_float_get_n.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES)
 RETURNS INT64
@@ -22,7 +26,7 @@ OPTIONS (
   library=["gs://$GCS_BUCKET/kll_sketch.js"],
   description = '''Returns the length of the input stream.
 Param sketch: the given sketch in serialized form.
-Returns stream length
+Returns: stream length
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 try {

--- a/kll/sqlx/kll_sketch_float_get_pmf.sqlx
+++ b/kll/sqlx/kll_sketch_float_get_pmf.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, split_points ARRAY<FLOAT64>, inclusive BOOL)
 RETURNS ARRAY<FLOAT64>
@@ -26,7 +30,7 @@ Param split_points: an array of M unique, monotonically increasing values that d
 Param inclusive: if true the rank of a value includes its own weight, and therefore
 if the sketch contains values equal to a slit point, then in PMF such values are
 included into the interval to the left of split point. Otherwise they are included into the interval to the right of split point.
-Returns an array of M+1 values each of which is an approximation
+Returns: an array of M+1 values each of which is an approximation
 to the fraction of the input stream values (the mass) that fall into one of those intervals.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""

--- a/kll/sqlx/kll_sketch_float_get_quantile.sqlx
+++ b/kll/sqlx/kll_sketch_float_get_quantile.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, rank FLOAT64, inclusive BOOL)
 RETURNS FLOAT64
@@ -24,7 +28,7 @@ OPTIONS (
 Param sketch: the given sketch in serialized form.
 Param rank: rank of a value in the hypothetical sorted stream.
 Param inclusive: if true, the given rank is considered inclusive (includes weight of a value)
-Returns an approximate quantile associated with the given rank.
+Returns: an approximate quantile associated with the given rank.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 try {

--- a/kll/sqlx/kll_sketch_float_get_rank.sqlx
+++ b/kll/sqlx/kll_sketch_float_get_rank.sqlx
@@ -1,30 +1,34 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, value FLOAT64, inclusive BOOL)
 RETURNS FLOAT64
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/kll_sketch.js"],
-  description = '''Returns an approximation to the normalized rank of the given value from 0 to 1, inclusive.
+  description = '''Returns an approximation to the normalized rank of the given value. from 0 to 1, inclusive.
 Param sketch: the given sketch in serialized form.
 Param value: value to be ranked.
 Param inclusive: if true the weight of the given value is included into the rank.
-Returns an approximate rank of the given value.
+Returns: an approximate rank of the given value.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 try {

--- a/kll/sqlx/kll_sketch_float_merge.sqlx
+++ b/kll/sqlx/kll_sketch_float_merge.sqlx
@@ -1,19 +1,23 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+config { hasOutput: true }
 
 CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(sketch BYTES, k INT NOT AGGREGATE)
 RETURNS BYTES
@@ -23,7 +27,7 @@ OPTIONS (
   description = '''Merges sketches from the given column.
 Param sketch: the column of values.
 Param k: the sketch accuracy/size parameter as an integer in the range [8, 65535].
-Returns a serialized KLL sketch as bytes.
+Returns: a serialized KLL sketch as bytes.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 import ModuleFactory from "gs://$GCS_BUCKET/kll_sketch.mjs";

--- a/kll/sqlx/kll_sketch_float_to_string.sqlx
+++ b/kll/sqlx/kll_sketch_float_to_string.sqlx
@@ -1,32 +1,36 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION ${self()}(base64 BYTES)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES)
 RETURNS STRING
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/kll_sketch.js"],
   description = '''Returns a summary string that represents the state of the given sketch.
-Param base64 the given sketch as base64 encoded bytes.
-Returns a string that represents the state of the given sketch.
+Param sketch: the given sketch as sketch encoded bytes.
+Returns: a string that represents the state of the given sketch.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 try {
-  var sketch = Module.kll_sketch_float.deserializeFromB64(base64);
+  var sketch = Module.kll_sketch_float.deserializeFromB64(sketch);
   try {
     return sketch.toString();
   } finally {

--- a/kll/test/kll_sketch_float_kolmogorov_smirnov_test.sqlx
+++ b/kll/test/kll_sketch_float_kolmogorov_smirnov_test.sqlx
@@ -27,8 +27,8 @@ OPTIONS (
   description = '''Performs the Kolmogorov-Smirnov Test between two KLL sketches.
 Note: if the given sketches have insufficient data or if the sketch sizes are too small,
 this will return false.
-Param sketchA: sketch 1 in serialized form.
-Param sketchB: sketch 2 in serialized form.
+Param sketchA: sketch A in serialized form.
+Param sketchB: sketch B in serialized form.
 Param pvalue: Target p-value. Typically 0.001 to 0.1, e.g. 0.05.
 Returns: boolean indicating whether we can reject the null hypothesis (that the sketches
 reflect the same underlying distribution) using the provided p-value.

--- a/kll/test/kll_sketch_float_kolmogorov_smirnov_test.sqlx
+++ b/kll/test/kll_sketch_float_kolmogorov_smirnov_test.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION ${self()}(sketch1 BYTES, sketch2 BYTES, pvalue FLOAT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, pvalue FLOAT64)
 RETURNS BOOL
 LANGUAGE js
 OPTIONS (
@@ -23,15 +27,15 @@ OPTIONS (
   description = '''Performs the Kolmogorov-Smirnov Test between two KLL sketches.
 Note: if the given sketches have insufficient data or if the sketch sizes are too small,
 this will return false.
-Param sketch1: sketch 1 in serialized form.
-Param sketch2: sketch 2 in serialized form.
+Param sketchA: sketch 1 in serialized form.
+Param sketchB: sketch 2 in serialized form.
 Param pvalue: Target p-value. Typically 0.001 to 0.1, e.g. 0.05.
-Returns boolean indicating whether we can reject the null hypothesis (that the sketches
+Returns: boolean indicating whether we can reject the null hypothesis (that the sketches
 reflect the same underlying distribution) using the provided p-value.
 For more details: https://datasketches.apache.org/docs/KLL/KLLSketch.html'''
 ) AS R"""
 try {
-  return Module.kolmogorovSmirnovTest(sketch1, sketch2, pvalue);
+  return Module.kolmogorovSmirnovTest(sketchA, sketchB, pvalue);
 } catch (e) {
   throw new Error(Module.getExceptionMessage(e));
 }


### PR DESCRIPTION
Reformatted the license header.

Added config { hasOutput: true }

Used ${self()} substitution.

Renamed input parameters to be more meaningful.

For low-valued integer parameters like lg_k and num_std_dev use BYTEINT.