### PR TITLE
CPC refactor:

### DIFF
--- a/cpc/sqlx/cpc_sketch_agg_string.sqlx
+++ b/cpc/sqlx/cpc_sketch_agg_string.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE AGGREGATE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_agg_string(str STRING, params STRUCT<lg_k INT, seed INT64> NOT AGGREGATE)
+config { hasOutput: true }
+
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(str STRING, params STRUCT<lg_k BYTEINT, seed INT64> NOT AGGREGATE)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
@@ -24,7 +28,7 @@ OPTIONS (
 Param str: the STRING column of identifiers.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: the seed to be used by the underlying hash function.
-Returns a Compact, Compressed CPC Sketch, as bytes, from which the cardinality can be obtained. 
+Returns: a Compact, Compressed CPC Sketch, as bytes, from which the cardinality can be obtained. 
 For more details: https://datasketches.apache.org/docs/CPC/CPC.html'''
 ) AS R"""
 import ModuleFactory from "gs://$GCS_BUCKET/cpc_sketch.mjs";

--- a/cpc/sqlx/cpc_sketch_agg_union.sqlx
+++ b/cpc/sqlx/cpc_sketch_agg_union.sqlx
@@ -1,21 +1,25 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE AGGREGATE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_agg_union(sketch BYTES, params STRUCT<lg_k INT, seed INT64> NOT AGGREGATE)
+config { hasOutput: true }
+
+CREATE OR REPLACE AGGREGATE FUNCTION ${self()}(sketch BYTES, params STRUCT<lg_k BYTEINT, seed INT64> NOT AGGREGATE)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
@@ -24,7 +28,7 @@ OPTIONS (
 Param sketch: the column of sketches. Each as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
-Returns a Compact, Compressed CPC Sketch, as bytes, from which the union cardinality can be obtained.
+Returns: a Compact, Compressed CPC Sketch, as bytes, from which the union cardinality can be obtained.
 For more details: https://datasketches.apache.org/docs/CPC/CPC.html'''
 ) AS R"""
 import ModuleFactory from "gs://$GCS_BUCKET/cpc_sketch.mjs";

--- a/cpc/sqlx/cpc_sketch_get_estimate.sqlx
+++ b/cpc/sqlx/cpc_sketch_get_estimate.sqlx
@@ -1,34 +1,38 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_get_estimate(base64 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, seed INT64)
 RETURNS FLOAT64
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/cpc_sketch.js"],
   description = '''Gets cardinality estimate and bounds from given sketch.
-Param base64: The given sketch to query as bytes.
+Param sketch: The given sketch to query as bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
-Returns a FLOAT64 value as the cardinality estimate.
+Returns: a FLOAT64 value as the cardinality estimate.
 For more details: https://datasketches.apache.org/docs/CPC/CPC.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.cpc_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.cpc_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return sketch.getEstimate();
   } finally {

--- a/cpc/sqlx/cpc_sketch_get_estimate_and_bounds.sqlx
+++ b/cpc/sqlx/cpc_sketch_get_estimate_and_bounds.sqlx
@@ -1,37 +1,41 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_get_estimate_and_bounds(base64 BYTES, num_std_devs INT, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, num_std_devs BYTEINT, seed INT64)
 RETURNS ARRAY<FLOAT64>
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/cpc_sketch.js"],
   description = '''Gets cardinality estimate and bounds from given sketch.
-Param base64: The given sketch to query as bytes.
+Param sketch: The given sketch to query as bytes.
 Param num_std_devs: The returned bounds will be based on the statistical confidence interval determined by the given number of standard deviations
 from the returned estimate. This number may be one of {1,2,3}, where 1 represents 68% confidence, 2 represents 95% confidence and 3 represents 99.7% confidence.
 For example, if the given num_std_devs = 2 and the returned values are {1000, 990, 1010} that means that with 95% confidence, the true value lies within the range [990, 1010].
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
-Returns an array of 3 FLOAT64 values as {estimate, lowerBound, upperBound}.
+Returns: an array of 3 FLOAT64 values as {estimate, lowerBound, upperBound}.
 For more details: https://datasketches.apache.org/docs/CPC/CPC.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.cpc_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.cpc_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return [sketch.getEstimate(), sketch.getLowerBound(num_std_devs), sketch.getUpperBound(num_std_devs)];
   } finally {

--- a/cpc/sqlx/cpc_sketch_scalar_union.sqlx
+++ b/cpc/sqlx/cpc_sketch_scalar_union.sqlx
@@ -1,28 +1,32 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_scalar_union(sketch1 BYTES, sketch2 BYTES, lg_k INT, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES, lg_k BYTEINT, seed INT64)
 RETURNS BYTES
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/cpc_sketch.js"],
   description = '''Computes a sketch that represents the scalar union of the two given sketches.
-Param sketch1: the first sketch as bytes.
-Param sketch2: the second sketch as bytes.
+Param sketchA: the first sketch as bytes.
+Param sketchB: the second sketch as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 26].
 Param seed: This is used to confirm that the given sketches were configured with the correct seed.
 Returns a Compact, Compressed Theta Sketch, as bytes, from which the union cardinality can be obtained.
@@ -33,8 +37,8 @@ const default_seed = BigInt(9001);
 try {
   var union = new Module.cpc_union(lg_k ? lg_k : default_lg_k, seed ? BigInt(seed) : default_seed);
   try {
-    union.updateWithB64(sketch1, seed ? BigInt(seed) : default_seed)
-    union.updateWithB64(sketch2, seed ? BigInt(seed) : default_seed)
+    union.updateWithB64(sketchA, seed ? BigInt(seed) : default_seed)
+    union.updateWithB64(sketchB, seed ? BigInt(seed) : default_seed)
     return union.getResultB64();
   } finally {
     union.delete();

--- a/cpc/sqlx/cpc_sketch_to_string.sqlx
+++ b/cpc/sqlx/cpc_sketch_to_string.sqlx
@@ -1,34 +1,38 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
-CREATE OR REPLACE FUNCTION `$BQ_PROJECT.$BQ_DATASET`.cpc_sketch_to_string(base64 BYTES, seed INT64)
+config { hasOutput: true }
+
+CREATE OR REPLACE FUNCTION ${self()}(sketch BYTES, seed INT64)
 RETURNS STRING
 LANGUAGE js
 OPTIONS (
   library=["gs://$GCS_BUCKET/cpc_sketch.js"],
   description = '''Returns a summary string that represents the state of the given sketch.
-Param base64 the given sketch as base64 encoded bytes.
+Param sketch the given sketch as sketch encoded bytes.
 Param seed: This is used to confirm that the given sketch was configured with the correct seed.
 Returns a string that represents the state of the given sketch.
 For more details: https://datasketches.apache.org/docs/CPC/CPC.html'''
 ) AS R"""
 const default_seed = BigInt(9001);
 try {
-  var sketch = Module.cpc_sketch.deserializeFromB64(base64, seed ? BigInt(seed) : default_seed);
+  var sketch = Module.cpc_sketch.deserializeFromB64(sketch, seed ? BigInt(seed) : default_seed);
   try {
     return sketch.toString();
   } finally {


### PR DESCRIPTION
Reformatted the license header.

Added config { hasOutput: true }

Used ${self()} substitution.

Renamed input parameters to be more meaningful.

For low-valued integer parameters like lg_k and num_std_dev use BYTEINT.