### PR TITLE
Updated the default param descriptions to make it easier to parse.

### DIFF
--- a/cpc/sqlx/cpc_sketch_agg_int64.sqlx
+++ b/cpc/sqlx/cpc_sketch_agg_int64.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given INT64 column.
 
 Param value: the INT64 column of identifiers.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a Compact, Compressed CPC Sketch, as BYTES 
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_agg_string.sqlx
+++ b/cpc/sqlx/cpc_sketch_agg_string.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given STRING column.
 
 Param str: the STRING column of identifiers.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a Compact, Compressed CPC Sketch, as BYTES 
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_agg_union.sqlx
+++ b/cpc/sqlx/cpc_sketch_agg_union.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the union of the given column of sketches.
 
 Param sketch: the column of sketches. Each as BYTES.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a Compact, Compressed CPC Sketch, as BYTES.
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_get_estimate.sqlx
+++ b/cpc/sqlx/cpc_sketch_get_estimate.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Gets cardinality estimate and bounds from given sketch.
 
 Param sketch: The given sketch to query as BYTES.
-Default seed.
+Defaults: seed = 9001.
 Returns: a FLOAT64 value as the cardinality estimate.
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_get_estimate_and_bounds.sqlx
+++ b/cpc/sqlx/cpc_sketch_get_estimate_and_bounds.sqlx
@@ -28,7 +28,7 @@ Param sketch: The given sketch to query as bytes.
 Param num_std_devs: The returned bounds will be based on the statistical confidence interval determined by the given number of standard deviations
   from the returned estimate. This number may be one of {1,2,3}, where 1 represents 68% confidence, 2 represents 95% confidence and 3 represents 99.7% confidence.
   For example, if the given num_std_devs = 2 and the returned values are {1000, 990, 1010} that means that with 95% confidence, the true value lies within the range [990, 1010].
-Default seed.
+Defaults: seed = 9001.
 Returns: a STRUCT with 3 FLOAT64 values as {estimate, lower_bound, upper_bound}.
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_to_string.sqlx
+++ b/cpc/sqlx/cpc_sketch_to_string.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Returns a summary string that represents the state of the given sketch.
 
 Param sketch the given sketch as BYTES.
-Default seed.
+Defaults: seed = 9001.
 Returns: a STRING that represents the state of the given sketch.
 
 For more information:

--- a/cpc/sqlx/cpc_sketch_union.sqlx
+++ b/cpc/sqlx/cpc_sketch_union.sqlx
@@ -26,7 +26,7 @@ OPTIONS (
 
 Param sketchA: the first sketch as BYTES.
 Param sketchB: the second sketch as BYTES.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a CPC Sketch, as BYTES.
 
 For more information:

--- a/hll/sqlx/hll_sketch_agg_int64.sqlx
+++ b/hll/sqlx/hll_sketch_agg_int64.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given INT64 column.
 
 Param value: the INT64 column of identifiers.
-Default lg_k and tgt_type.
+Defaults: lg_k = 12, tgt_type = HLL_4.
 Returns: an HLL Sketch, as BYTES.
 
 For more information:

--- a/hll/sqlx/hll_sketch_agg_string.sqlx
+++ b/hll/sqlx/hll_sketch_agg_string.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given STRING column.
 
 Param str: the STRING column of identifiers.
-Default lg_k and tgt_type.
+Defaults: lg_k = 12, tgt_type = HLL_4.
 Returns: an HLL Sketch, as BYTES.
 
 For more information:

--- a/hll/sqlx/hll_sketch_agg_union.sqlx
+++ b/hll/sqlx/hll_sketch_agg_union.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the union of the given column of sketches.
 
 Param sketch: the column of sketches. Each as BYTES.
-Default lg_k and tgt_type.
+Defaults: lg_k = 12, tgt_type = HLL_4.
 Returns: an HLL Sketch, as BYTES.
 
 For more information:

--- a/hll/sqlx/hll_sketch_union.sqlx
+++ b/hll/sqlx/hll_sketch_union.sqlx
@@ -23,9 +23,10 @@ CREATE OR REPLACE FUNCTION ${self()}(sketchA BYTES, sketchB BYTES)
 RETURNS BYTES
 OPTIONS (
   description = '''Computes a sketch that represents the union of the two given sketches.
+
 Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
-Default lg_k and tgt_type
+Defaults: lg_k = 12, tgt_type = HLL_4.
 Returns: an HLL Sketch, as BYTES.
 
 For more information:

--- a/hll/sqlx/hll_sketch_union_lgk_type.sqlx
+++ b/hll/sqlx/hll_sketch_union_lgk_type.sqlx
@@ -26,6 +26,7 @@ OPTIONS (
   library=["gs://$GCS_BUCKET/hll_sketch.js"],
   js_parameter_encoding_mode='STANDARD',
   description = '''Computes a sketch that represents the union of the two given sketches.
+
 Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
 Param lg_k: the sketch accuracy/size parameter as an integer in the range [4, 21].

--- a/theta/sqlx/theta_sketch_a_not_b.sqlx
+++ b/theta/sqlx/theta_sketch_a_not_b.sqlx
@@ -26,7 +26,7 @@ OPTIONS (
 
 Param sketchA: the first sketch "A" as bytes.
 Param sketchB: the second sketch "B" as bytes.
-Default seed.
+Defaults: seed = 9001.
 Returns: a Compact, Compressed Theta Sketch, as BYTES.
 
 For more information:

--- a/theta/sqlx/theta_sketch_agg_int64.sqlx
+++ b/theta/sqlx/theta_sketch_agg_int64.sqlx
@@ -25,9 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given INT64 column.
   
 Param value: the INT64 column of identifiers.
-Param lg_k: assume default = 12
-Param seed: assume default = 9001
-Param p: assume default = 1.0
+Defaults: lg_k = 12, seed = 9001, p = 1.0.
 Returns: a Compact, Compressed Theta Sketch, as BYTES. 
 
 For more information:

--- a/theta/sqlx/theta_sketch_agg_string.sqlx
+++ b/theta/sqlx/theta_sketch_agg_string.sqlx
@@ -25,9 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the cardinality of the given STRING column.
   
 Param str: the STRING column of identifiers.
-Param lg_k: assume default = 12
-Param seed: assume default = 9001
-Param p: assume default = 1.0
+Defaults: lg_k = 12, seed = 9001, p = 1.0.
 Returns: a Compact, Compressed Theta Sketch, as BYTES. 
 
 For more information:

--- a/theta/sqlx/theta_sketch_agg_union.sqlx
+++ b/theta/sqlx/theta_sketch_agg_union.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Creates a sketch that represents the union of the given column of sketches.
 
 Param sketch: the column of sketches. Each as BYTES.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a Compact, Compressed Theta Sketch, as BYTES.
 
 For more information:

--- a/theta/sqlx/theta_sketch_get_estimate.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Gets cardinality estimate and bounds from given sketch.
   
 Param sketch: The given sketch to query as BYTES.
-Default seed.
+Defaults: seed = 9001.
 Returns: a FLOAT64 value as the cardinality estimate.
 
 For more information:

--- a/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
+++ b/theta/sqlx/theta_sketch_get_estimate_and_bounds.sqlx
@@ -31,7 +31,7 @@ Param num_std_devs: The returned bounds will be based on the statistical confide
   2 represents 95% confidence and 3 represents 99.7% confidence.
   For example, if the given num_std_devs = 2 and the returned values are {1000, 990, 1010}
   that means that with 95% confidence, the true value lies within the range [990, 1010].
-Default seed.
+Defaults: seed = 9001.
 Returns: a STRUCT with three FLOAT64 values as {estimate, lower_bound, upper_bound}.
 
 For more information:

--- a/theta/sqlx/theta_sketch_intersection.sqlx
+++ b/theta/sqlx/theta_sketch_intersection.sqlx
@@ -26,7 +26,7 @@ OPTIONS (
 
 Param sketchA: the first sketch as BYTES.
 Param sketchB: the second sketch as BYTES.
-Default seed.
+Defaults: seed = 9001.
 Returns: a Compact, Compressed Theta Sketch, as BYTES.
 
 For more information:

--- a/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
+++ b/theta/sqlx/theta_sketch_jaccard_similarity.sqlx
@@ -29,7 +29,7 @@ A Jaccard of .95 means the overlap between the two sets is 95% of the union of t
 
 Param sketchA: the first sketch as bytes.
 Param sketchB: the second sketch as bytes.
-Default seed.
+Defaults: seed = 9001.
 Returns: a STRUCT with three FLOAT64 values {lower_bound, estimate, upper_bound} of the Jaccard index.
 
 For more information:

--- a/theta/sqlx/theta_sketch_to_string.sqlx
+++ b/theta/sqlx/theta_sketch_to_string.sqlx
@@ -25,7 +25,7 @@ OPTIONS (
   description = '''Returns a summary string that represents the state of the given sketch.
 
 Param sketch: the given sketch as BYTES.
-Default seed.
+Defaults: seed = 9001.
 Returns: a STRING that represents the state of the given sketch.
 
 For more information:

--- a/theta/sqlx/theta_sketch_union.sqlx
+++ b/theta/sqlx/theta_sketch_union.sqlx
@@ -26,7 +26,7 @@ OPTIONS (
 
 Param sketchA: the first sketch as BYTES.
 Param sketchB: the second sketch as BYTES.
-Default lg_k and seed.
+Defaults: lg_k = 12, seed = 9001.
 Returns: a Compact, Compressed Theta Sketch, as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_a_not_b.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_a_not_b.sqlx
@@ -28,7 +28,7 @@ This function only applies to Tuple Sketches with an INT64 summary column.
   
 Param sketchA: the first sketch "A" as BYTES. This may not be NULL.
 Param sketchB: the second sketch "B" as BYTES. This may not be NULL.
-Assumed Default Param seed: 9001
+Defaults: seed = 9001.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_agg_int64.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_agg_int64.sqlx
@@ -29,10 +29,7 @@ This function only applies to Tuple Sketches with an INT64 Key column and an INT
 
 Param key: the INT64 key column of identifiers. This may not be NULL.
 Param value: the INT64 value column associated with each key. This may not be NULL.
-Assumed Default Param lg_k: 12.
-Assumed Default Param seed: 9001.
-Assumed Default Param p: 1.0.
-Assumed Default Param mode: SUM.
+Defaults: lg_k = 12, seed = 9001, p = 1.0, mode = SUM.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_agg_string.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_agg_string.sqlx
@@ -29,10 +29,7 @@ This function only applies to Tuple Sketches with an STRING Key column and an IN
  
 Param key: the STRING column of identifiers. This may not be NULL.
 Param value: the INT64 value column associated with each key. This may not be NULL.
-Assumed Default Param lg_k: 12
-Assumed Default Param seed: 9001
-Assumed Default Param p: 1.0
-Assumed Default Param mode: SUM.
+Defaults: lg_k = 12, seed = 9001, p = 1.0, mode = SUM.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_agg_union.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_agg_union.sqlx
@@ -27,9 +27,7 @@ Note that cardinality estimation accuracy, plots, and error tables are the same 
 This function only applies to Tuple Sketches with an INT64 summary column.
 
 Param sketch: the given column of Tuple Sketches with an INT64 summary column. This may not be NULL.
-Assumed Default Param lg_k: 12.
-Assumed Default Param seed: 9001.
-Assumed Default Param mode: SUM.
+Defaults: lg_k = 12, seed = 9001, mode = SUM.
 Returns: a Compact Tuple Sketch as BYTES. 
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_filter_low_high.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_filter_low_high.sqlx
@@ -31,7 +31,7 @@ This function only applies to Tuple Sketches with an INT64 summary column.
 Param sketch: the given Tuple Sketch. This may not be NULL.
 Param low: the given low INT64. This may not be NULL.
 Param high: the given high INT64. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_from_theta_sketch.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_from_theta_sketch.sqlx
@@ -27,7 +27,7 @@ Note that cardinality estimation accuracy, plots, and error tables are the same 
 
 Param sketch: the given Theta Sketch. This may not be NULL.
 Param value: the given INT64 value. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: a Tuple Sketch with an INT64 summary column as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_get_estimate.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_get_estimate.sqlx
@@ -28,7 +28,7 @@ Note that cardinality estimation accuracy, plots, and error tables are the same 
 This function only applies to Tuple Sketches with an INT64 summary column.
   
 Param sketch: the given Tuple Sketch. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: the cardinality estimate of the given Tuple Sketch
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_intersection.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_intersection.sqlx
@@ -28,7 +28,7 @@ This function only applies to Tuple Sketches with an INT64 summary column.
 
 Param sketchA: the first sketch "A" as BYTES.
 Param sketchB: the second sketch "B" as BYTES.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_jaccard_similarity.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_jaccard_similarity.sqlx
@@ -30,7 +30,7 @@ This function only applies to Tuple Sketches with an INT64 summary column.
 
 Param sketchA: the first sketch as bytes. This may not be NULL.
 Param sketchB: the second sketch as bytes. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: a STRUCT with three FLOAT64 values {lower_bound, estimate, upper_bound} of the Jaccard index.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_to_string.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_to_string.sqlx
@@ -27,7 +27,7 @@ OPTIONS (
   This function only applies to Tuple Sketches with an INT64 summary column.
 
 Param sketch: the sketch to be summarized. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: A human readable STRING that is a short summary of the state of this sketch.
 
 For more information:

--- a/tuple/sqlx/tuple_sketch_int64_union.sqlx
+++ b/tuple/sqlx/tuple_sketch_int64_union.sqlx
@@ -28,7 +28,7 @@ This function only applies to Tuple Sketches with an INT64 summary column.
 
 Param sketchA: the first sketch "A" as BYTES. This may not be NULL.
 Param sketchB: the second sketch "B" as BYTES. This may not be NULL.
-Assumed Default Param seed: 9001.
+Defaults: seed = 9001.
 Returns: a Compact Tuple Sketch as BYTES.
 
 For more information:


### PR DESCRIPTION
There was a missing empty line in one case.