### PR TITLE
download datasketches-cpp instead of using submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "datasketches-cpp"]
-	path = datasketches-cpp
-	url = https://github.com/apache/datasketches-cpp

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,17 @@ MODULES := theta tuple cpc hll kll fi tdigest req
 $(MODULES):
 	$(MAKE) -C $@
 
-.PHONY: all clean init $(MODULES)
+.PHONY: all clean init test unittest readme $(MODULES)
 .DEFAULT_GOAL := all
 
-all: $(MODULES)
+all: datasketches-cpp $(MODULES)
+
+DATASKETCHES_CPP_VERSION = 5.1.0
+datasketches-cpp:
+	wget https://github.com/apache/datasketches-cpp/archive/refs/tags/$(DATASKETCHES_CPP_VERSION).zip
+	mv $(DATASKETCHES_CPP_VERSION).zip datasketches-cpp-$(DATASKETCHES_CPP_VERSION).zip
+	unzip datasketches-cpp-$(DATASKETCHES_CPP_VERSION).zip
+	ln -s datasketches-cpp-$(DATASKETCHES_CPP_VERSION) datasketches-cpp
 
 MODCLEAN = $(addsuffix .clean, $(MODULES))
 


### PR DESCRIPTION
We are going to have Apache release artifact in the form of a ZIP archive of the repository, and there is no notion of Git submodule. Let's have a Makefile target bring in the specified version of the datasketches-cpp library.