### PR TITLE
render examples with bqutil.datasketches prefix in function calls

### DIFF
--- a/cpc/README.md
+++ b/cpc/README.md
@@ -60,19 +60,19 @@ page for how to contact us.
 
 # using defaults
 # expected 5
-select `$BQ_DATASET`.cpc_sketch_get_estimate(
-  `$BQ_DATASET`.cpc_sketch_union(
-    (select `$BQ_DATASET`.cpc_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.cpc_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.cpc_sketch_get_estimate(
+  bqutil.datasketches.cpc_sketch_union(
+    (select bqutil.datasketches.cpc_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.cpc_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # using full signatures
 # expected 5
-select `$BQ_DATASET`.cpc_sketch_get_estimate_seed(
-  `$BQ_DATASET`.cpc_sketch_union_lgk_seed(
-    (select `$BQ_DATASET`.cpc_sketch_agg_string_lgk_seed(str, struct<byteint, int64>(10, 111)) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.cpc_sketch_agg_string_lgk_seed(str, struct<byteint, int64>(10, 111)) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.cpc_sketch_get_estimate_seed(
+  bqutil.datasketches.cpc_sketch_union_lgk_seed(
+    (select bqutil.datasketches.cpc_sketch_agg_string_lgk_seed(str, struct<byteint, int64>(10, 111)) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.cpc_sketch_agg_string_lgk_seed(str, struct<byteint, int64>(10, 111)) from unnest(["c", "d", "e"]) as str),
     10,
     111
   ),
@@ -80,48 +80,48 @@ select `$BQ_DATASET`.cpc_sketch_get_estimate_seed(
 );
 
 # using defaults
-create or replace table `$BQ_DATASET`.cpc_sketch(sketch bytes);
+create or replace temp table cpc_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.cpc_sketch
-(select `$BQ_DATASET`.cpc_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.cpc_sketch
-(select `$BQ_DATASET`.cpc_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into cpc_sketch
+(select bqutil.datasketches.cpc_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into cpc_sketch
+(select bqutil.datasketches.cpc_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
-select `$BQ_DATASET`.cpc_sketch_to_string(sketch) from `$BQ_DATASET`.cpc_sketch;
+select bqutil.datasketches.cpc_sketch_to_string(sketch) from cpc_sketch;
 
 # expected about 20000
-select `$BQ_DATASET`.cpc_sketch_get_estimate(
-  `$BQ_DATASET`.cpc_sketch_agg_union(sketch)
-) from `$BQ_DATASET`.cpc_sketch;
+select bqutil.datasketches.cpc_sketch_get_estimate(
+  bqutil.datasketches.cpc_sketch_agg_union(sketch)
+) from cpc_sketch;
 
-select `$BQ_DATASET`.cpc_sketch_get_estimate_and_bounds(
-  `$BQ_DATASET`.cpc_sketch_agg_union(sketch),
+select bqutil.datasketches.cpc_sketch_get_estimate_and_bounds(
+  bqutil.datasketches.cpc_sketch_agg_union(sketch),
   3
-) from `$BQ_DATASET`.cpc_sketch;
+) from cpc_sketch;
 
-drop table `$BQ_DATASET`.cpc_sketch;
+drop table cpc_sketch;
 
 # using full signatures
-create or replace table `$BQ_DATASET`.cpc_sketch(sketch bytes);
+create or replace temp table cpc_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.cpc_sketch
-(select `$BQ_DATASET`.cpc_sketch_agg_int64_lgk_seed(value, struct<byteint, int64>(10, 111)) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.cpc_sketch
-(select `$BQ_DATASET`.cpc_sketch_agg_int64_lgk_seed(value, struct<byteint, int64>(10, 111)) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into cpc_sketch
+(select bqutil.datasketches.cpc_sketch_agg_int64_lgk_seed(value, struct<byteint, int64>(10, 111)) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into cpc_sketch
+(select bqutil.datasketches.cpc_sketch_agg_int64_lgk_seed(value, struct<byteint, int64>(10, 111)) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
-select `$BQ_DATASET`.cpc_sketch_to_string_seed(sketch, 111) from `$BQ_DATASET`.cpc_sketch;
+select bqutil.datasketches.cpc_sketch_to_string_seed(sketch, 111) from cpc_sketch;
 
 # expected about 20000
-select `$BQ_DATASET`.cpc_sketch_get_estimate_seed(
-  `$BQ_DATASET`.cpc_sketch_agg_union_lgk_seed(sketch, struct<byteint, int64>(10, 111)),
+select bqutil.datasketches.cpc_sketch_get_estimate_seed(
+  bqutil.datasketches.cpc_sketch_agg_union_lgk_seed(sketch, struct<byteint, int64>(10, 111)),
   111
-) from `$BQ_DATASET`.cpc_sketch;
+) from cpc_sketch;
 
-select `$BQ_DATASET`.cpc_sketch_get_estimate_and_bounds_seed(
-  `$BQ_DATASET`.cpc_sketch_agg_union_lgk_seed(sketch, struct<byteint, int64>(10, 111)),
+select bqutil.datasketches.cpc_sketch_get_estimate_and_bounds_seed(
+  bqutil.datasketches.cpc_sketch_agg_union_lgk_seed(sketch, struct<byteint, int64>(10, 111)),
   3,
   111
-) from `$BQ_DATASET`.cpc_sketch;
+) from cpc_sketch;
 
-drop table `$BQ_DATASET`.cpc_sketch;
+drop table cpc_sketch;
 ```

--- a/fi/README.md
+++ b/fi/README.md
@@ -47,17 +47,17 @@ page for how to contact us.
 
 ```sql
 
-select `$BQ_DATASET`.frequent_strings_sketch_to_string(`$BQ_DATASET`.frequent_strings_sketch_build(str, 1, 5)) from unnest(["a", "b", "c"]) as str;
+select bqutil.datasketches.frequent_strings_sketch_to_string(bqutil.datasketches.frequent_strings_sketch_build(str, 1, 5)) from unnest(["a", "b", "c"]) as str;
 
-create or replace table `$BQ_DATASET`.fs_sketch(sketch bytes);
+create or replace temp table fs_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.fs_sketch
-(select `$BQ_DATASET`.frequent_strings_sketch_build(str, 1, 5) from unnest(["a", "b", "c", "d"]) as str);
+insert into fs_sketch
+(select bqutil.datasketches.frequent_strings_sketch_build(str, 1, 5) from unnest(["a", "b", "c", "d"]) as str);
 
-insert into `$BQ_DATASET`.fs_sketch
-(select `$BQ_DATASET`.frequent_strings_sketch_build(str, 1, 5) from unnest(["a", "a", "c"]) as str);
+insert into fs_sketch
+(select bqutil.datasketches.frequent_strings_sketch_build(str, 1, 5) from unnest(["a", "a", "c"]) as str);
 
-select `$BQ_DATASET`.frequent_strings_sketch_get_result(`$BQ_DATASET`.frequent_strings_sketch_merge(sketch, 5), "NO_FALSE_NEGATIVES", null) from `$BQ_DATASET`.fs_sketch;
+select bqutil.datasketches.frequent_strings_sketch_get_result(bqutil.datasketches.frequent_strings_sketch_merge(sketch, 5), "NO_FALSE_NEGATIVES", null) from fs_sketch;
 
-drop table `$BQ_DATASET`.fs_sketch;
+drop table fs_sketch;
 ```

--- a/hll/README.md
+++ b/hll/README.md
@@ -54,59 +54,59 @@ page for how to contact us.
 ```sql
 
 # expected 3
-select `$BQ_DATASET`.hll_sketch_get_estimate(`$BQ_DATASET`.hll_sketch_agg_string(s)) from unnest(["a", "b", "c"]) as s;
+select bqutil.datasketches.hll_sketch_get_estimate(bqutil.datasketches.hll_sketch_agg_string(s)) from unnest(["a", "b", "c"]) as s;
 
-select `$BQ_DATASET`.hll_sketch_to_string(`$BQ_DATASET`.hll_sketch_agg_string(s)) from unnest(["a", "b", "c"]) as s;
+select bqutil.datasketches.hll_sketch_to_string(bqutil.datasketches.hll_sketch_agg_string(s)) from unnest(["a", "b", "c"]) as s;
 
 # expected 5
-select `$BQ_DATASET`.hll_sketch_get_estimate_and_bounds(
-  `$BQ_DATASET`.hll_sketch_union_lgk_type(
-    (select `$BQ_DATASET`.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.hll_sketch_get_estimate_and_bounds(
+  bqutil.datasketches.hll_sketch_union_lgk_type(
+    (select bqutil.datasketches.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["c", "d", "e"]) as str),
     10,
     "HLL_8"
   ),
   2
 );
 
-select `$BQ_DATASET`.hll_sketch_to_string(
-  `$BQ_DATASET`.hll_sketch_union_lgk_type(
-    (select `$BQ_DATASET`.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.hll_sketch_to_string(
+  bqutil.datasketches.hll_sketch_union_lgk_type(
+    (select bqutil.datasketches.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.hll_sketch_agg_string_lgk_type(str, struct<byteint, string>(10, "HLL_8")) from unnest(["c", "d", "e"]) as str),
     10,
     "HLL_8"
   )
 );
 
-create or replace table `$BQ_DATASET`.hll_sketch(sketch bytes);
+create or replace temp table hll_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.hll_sketch
-(select `$BQ_DATASET`.hll_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.hll_sketch
-(select `$BQ_DATASET`.hll_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
-
-# expected estimate about 20000
-select `$BQ_DATASET`.hll_sketch_to_string(
-  `$BQ_DATASET`.hll_sketch_agg_union(sketch)
-) from `$BQ_DATASET`.hll_sketch;
-
-select `$BQ_DATASET`.hll_sketch_to_string(
-  `$BQ_DATASET`.hll_sketch_agg_union_lgk_type(sketch, struct<byteint, string>(10, "HLL_6"))
-) from `$BQ_DATASET`.hll_sketch;
-
-drop table `$BQ_DATASET`.hll_sketch;
-
-create or replace table `$BQ_DATASET`.hll_sketch(sketch bytes);
-
-insert into `$BQ_DATASET`.hll_sketch
-(select `$BQ_DATASET`.hll_sketch_agg_int64_lgk_type(value, struct<int, string>(8, "HLL_6")) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.hll_sketch
-(select `$BQ_DATASET`.hll_sketch_agg_int64_lgk_type(value, struct<int, string>(8, "HLL_6")) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into hll_sketch
+(select bqutil.datasketches.hll_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into hll_sketch
+(select bqutil.datasketches.hll_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
 # expected estimate about 20000
-select `$BQ_DATASET`.hll_sketch_to_string(
-  `$BQ_DATASET`.hll_sketch_agg_union_lgk_type(sketch, struct<byteint, string>(8, "HLL_6"))
-) from `$BQ_DATASET`.hll_sketch;
+select bqutil.datasketches.hll_sketch_to_string(
+  bqutil.datasketches.hll_sketch_agg_union(sketch)
+) from hll_sketch;
 
-drop table `$BQ_DATASET`.hll_sketch;
+select bqutil.datasketches.hll_sketch_to_string(
+  bqutil.datasketches.hll_sketch_agg_union_lgk_type(sketch, struct<byteint, string>(10, "HLL_6"))
+) from hll_sketch;
+
+drop table hll_sketch;
+
+create or replace temp table hll_sketch(sketch bytes);
+
+insert into hll_sketch
+(select bqutil.datasketches.hll_sketch_agg_int64_lgk_type(value, struct<int, string>(8, "HLL_6")) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into hll_sketch
+(select bqutil.datasketches.hll_sketch_agg_int64_lgk_type(value, struct<int, string>(8, "HLL_6")) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+
+# expected estimate about 20000
+select bqutil.datasketches.hll_sketch_to_string(
+  bqutil.datasketches.hll_sketch_agg_union_lgk_type(sketch, struct<byteint, string>(8, "HLL_6"))
+) from hll_sketch;
+
+drop table hll_sketch;
 ```

--- a/kll/README.md
+++ b/kll/README.md
@@ -57,63 +57,63 @@ page for how to contact us.
 
 ```sql
 
-create or replace table `$BQ_DATASET`.kll_sketch(sketch bytes);
+create or replace temp table kll_sketch(sketch bytes);
 
 # using default
-insert into `$BQ_DATASET`.kll_sketch
-(select `$BQ_DATASET`.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
+insert into kll_sketch
+(select bqutil.datasketches.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
 
 # using full signature
-insert into `$BQ_DATASET`.kll_sketch
-(select `$BQ_DATASET`.kll_sketch_float_build_k(value, 100) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
+insert into kll_sketch
+(select bqutil.datasketches.kll_sketch_float_build_k(value, 100) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
 
-select `$BQ_DATASET`.kll_sketch_float_to_string(sketch) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_to_string(sketch) from kll_sketch;
 
 # using default
-select `$BQ_DATASET`.kll_sketch_float_to_string(`$BQ_DATASET`.kll_sketch_float_merge(sketch)) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_to_string(bqutil.datasketches.kll_sketch_float_merge(sketch)) from kll_sketch;
 
 # using full signature
-select `$BQ_DATASET`.kll_sketch_float_to_string(`$BQ_DATASET`.kll_sketch_float_merge_k(sketch, 100)) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_to_string(bqutil.datasketches.kll_sketch_float_merge_k(sketch, 100)) from kll_sketch;
 
 # expected 0.5
-select `$BQ_DATASET`.kll_sketch_float_get_rank(`$BQ_DATASET`.kll_sketch_float_merge(sketch), 10, true) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_rank(bqutil.datasketches.kll_sketch_float_merge(sketch), 10, true) from kll_sketch;
 
 # expected 10
-select `$BQ_DATASET`.kll_sketch_float_get_quantile(`$BQ_DATASET`.kll_sketch_float_merge(sketch), 0.5, true) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_quantile(bqutil.datasketches.kll_sketch_float_merge(sketch), 0.5, true) from kll_sketch;
 
 # expected 20
-select `$BQ_DATASET`.kll_sketch_float_get_n(`$BQ_DATASET`.kll_sketch_float_merge(sketch)) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_n(bqutil.datasketches.kll_sketch_float_merge(sketch)) from kll_sketch;
 
 # expected 0.5, 0.5
-select `$BQ_DATASET`.kll_sketch_float_get_pmf(`$BQ_DATASET`.kll_sketch_float_merge(sketch), [10.0], true) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_pmf(bqutil.datasketches.kll_sketch_float_merge(sketch), [10.0], true) from kll_sketch;
 
 # expected 0.5, 1
-select `$BQ_DATASET`.kll_sketch_float_get_cdf(`$BQ_DATASET`.kll_sketch_float_merge(sketch), [10.0], true) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_cdf(bqutil.datasketches.kll_sketch_float_merge(sketch), [10.0], true) from kll_sketch;
 
 # expected 1
-select `$BQ_DATASET`.kll_sketch_float_get_min_value(`$BQ_DATASET`.kll_sketch_float_merge(sketch)) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_min_value(bqutil.datasketches.kll_sketch_float_merge(sketch)) from kll_sketch;
 
 # expected 20
-select `$BQ_DATASET`.kll_sketch_float_get_max_value(`$BQ_DATASET`.kll_sketch_float_merge(sketch)) from `$BQ_DATASET`.kll_sketch;
+select bqutil.datasketches.kll_sketch_float_get_max_value(bqutil.datasketches.kll_sketch_float_merge(sketch)) from kll_sketch;
 
-drop table `$BQ_DATASET`.kll_sketch;
+drop table kll_sketch;
 
 # expected about 1.3%
-select `$BQ_DATASET`.kll_sketch_float_get_normalized_rank_error(`$BQ_DATASET`.kll_sketch_float_build(value), false) from unnest(generate_array(1, 10000)) as value;
+select bqutil.datasketches.kll_sketch_float_get_normalized_rank_error(bqutil.datasketches.kll_sketch_float_build(value), false) from unnest(generate_array(1, 10000)) as value;
 
-select `$BQ_DATASET`.kll_sketch_float_get_num_retained(`$BQ_DATASET`.kll_sketch_float_build(value)) from unnest(generate_array(1, 10000)) as value;
+select bqutil.datasketches.kll_sketch_float_get_num_retained(bqutil.datasketches.kll_sketch_float_build(value)) from unnest(generate_array(1, 10000)) as value;
 
 # expected false
-select `$BQ_DATASET`.kll_sketch_float_kolmogorov_smirnov(
-  (select `$BQ_DATASET`.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
-  (select `$BQ_DATASET`.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
+select bqutil.datasketches.kll_sketch_float_kolmogorov_smirnov(
+  (select bqutil.datasketches.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
+  (select bqutil.datasketches.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
   0.05
 );
 
 # expected true
-select `$BQ_DATASET`.kll_sketch_float_kolmogorov_smirnov(
-  (select `$BQ_DATASET`.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
-  (select `$BQ_DATASET`.kll_sketch_float_build(value) from unnest([11,12,13,14,15,16,17,18,19,20]) as value),
+select bqutil.datasketches.kll_sketch_float_kolmogorov_smirnov(
+  (select bqutil.datasketches.kll_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value),
+  (select bqutil.datasketches.kll_sketch_float_build(value) from unnest([11,12,13,14,15,16,17,18,19,20]) as value),
   0.05
 );
 ```

--- a/readme_generator.py
+++ b/readme_generator.py
@@ -155,6 +155,9 @@ def generate_readme(template_path: str, function_index: dict, examples_path: str
           break
       sql_code_without_license = "\n".join(sql_code_lines[start_index:])
 
+      # add project and dataset available in BQ
+      sql_code_without_license = sql_code_without_license.replace('`$BQ_DATASET`', 'bqutil.datasketches')
+
       # Add the SQL code in a code block
       output_lines.append(f"```sql\n{sql_code_without_license}\n```\n")
 

--- a/req/README.md
+++ b/req/README.md
@@ -61,53 +61,53 @@ page for how to contact us.
 
 # using defaults
 
-create or replace table `$BQ_DATASET`.req_sketch(sketch bytes);
+create or replace temp table req_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.req_sketch
-(select `$BQ_DATASET`.req_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
+insert into req_sketch
+(select bqutil.datasketches.req_sketch_float_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
 
-insert into `$BQ_DATASET`.req_sketch
-(select `$BQ_DATASET`.req_sketch_float_build(value) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
+insert into req_sketch
+(select bqutil.datasketches.req_sketch_float_build(value) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
 
-select `$BQ_DATASET`.req_sketch_float_to_string(`$BQ_DATASET`.req_sketch_float_merge(sketch)) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_to_string(bqutil.datasketches.req_sketch_float_merge(sketch)) from req_sketch;
 
 # expected 0.5
-select `$BQ_DATASET`.req_sketch_float_get_rank(`$BQ_DATASET`.req_sketch_float_merge(sketch), 10, true) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_rank(bqutil.datasketches.req_sketch_float_merge(sketch), 10, true) from req_sketch;
 
 # expected 10
-select `$BQ_DATASET`.req_sketch_float_get_quantile(`$BQ_DATASET`.req_sketch_float_merge(sketch), 0.5, true) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_quantile(bqutil.datasketches.req_sketch_float_merge(sketch), 0.5, true) from req_sketch;
 
 # expected 0.5, 0.5
-select `$BQ_DATASET`.req_sketch_float_get_pmf(`$BQ_DATASET`.req_sketch_float_merge(sketch), [10.0], true) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_pmf(bqutil.datasketches.req_sketch_float_merge(sketch), [10.0], true) from req_sketch;
 
 # expected 0.5, 1
-select `$BQ_DATASET`.req_sketch_float_get_cdf(`$BQ_DATASET`.req_sketch_float_merge(sketch), [10.0], true) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_cdf(bqutil.datasketches.req_sketch_float_merge(sketch), [10.0], true) from req_sketch;
 
 # expected 1
-select `$BQ_DATASET`.req_sketch_float_get_min_value(`$BQ_DATASET`.req_sketch_float_merge(sketch)) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_min_value(bqutil.datasketches.req_sketch_float_merge(sketch)) from req_sketch;
 
 # expected 20
-select `$BQ_DATASET`.req_sketch_float_get_max_value(`$BQ_DATASET`.req_sketch_float_merge(sketch)) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_max_value(bqutil.datasketches.req_sketch_float_merge(sketch)) from req_sketch;
 
 # expected 20
-select `$BQ_DATASET`.req_sketch_float_get_n(`$BQ_DATASET`.req_sketch_float_merge(sketch)) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_n(bqutil.datasketches.req_sketch_float_merge(sketch)) from req_sketch;
 
 # expected 20
-select `$BQ_DATASET`.req_sketch_float_get_num_retained(`$BQ_DATASET`.req_sketch_float_merge(sketch)) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_get_num_retained(bqutil.datasketches.req_sketch_float_merge(sketch)) from req_sketch;
 
-drop table `$BQ_DATASET`.req_sketch;
+drop table req_sketch;
 
 # using full signatures
 
-create or replace table `$BQ_DATASET`.req_sketch(sketch bytes);
+create or replace temp table req_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.req_sketch
-(select `$BQ_DATASET`.req_sketch_float_build_k_hra(value, struct<int, bool>(10, false)) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
+insert into req_sketch
+(select bqutil.datasketches.req_sketch_float_build_k_hra(value, struct<int, bool>(10, false)) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
 
-insert into `$BQ_DATASET`.req_sketch
-(select `$BQ_DATASET`.req_sketch_float_build_k_hra(value, struct<int, bool>(10, false)) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
+insert into req_sketch
+(select bqutil.datasketches.req_sketch_float_build_k_hra(value, struct<int, bool>(10, false)) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
 
-select `$BQ_DATASET`.req_sketch_float_to_string(`$BQ_DATASET`.req_sketch_float_merge_k_hra(sketch, struct<int, bool>(10, false))) from `$BQ_DATASET`.req_sketch;
+select bqutil.datasketches.req_sketch_float_to_string(bqutil.datasketches.req_sketch_float_merge_k_hra(sketch, struct<int, bool>(10, false))) from req_sketch;
 
-drop table `$BQ_DATASET`.req_sketch;
+drop table req_sketch;
 ```

--- a/tdigest/README.md
+++ b/tdigest/README.md
@@ -51,38 +51,38 @@ page for how to contact us.
 
 ```sql
 
-create or replace table `$BQ_DATASET`.tdigest_double(sketch bytes);
+create or replace temp table tdigest_double(sketch bytes);
 
 # using default
-insert into `$BQ_DATASET`.tdigest_double
-(select `$BQ_DATASET`.tdigest_double_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
+insert into tdigest_double
+(select bqutil.datasketches.tdigest_double_build(value) from unnest([1,2,3,4,5,6,7,8,9,10]) as value);
 
 # using full signature
-insert into `$BQ_DATASET`.tdigest_double
-(select `$BQ_DATASET`.tdigest_double_build_k(value, 100) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
+insert into tdigest_double
+(select bqutil.datasketches.tdigest_double_build_k(value, 100) from unnest([11,12,13,14,15,16,17,18,19,20]) as value);
 
-select `$BQ_DATASET`.tdigest_double_to_string(sketch) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_to_string(sketch) from tdigest_double;
 
 # using default
-select `$BQ_DATASET`.tdigest_double_to_string(`$BQ_DATASET`.tdigest_double_merge(sketch)) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_to_string(bqutil.datasketches.tdigest_double_merge(sketch)) from tdigest_double;
 
 # using full signature
-select `$BQ_DATASET`.tdigest_double_to_string(`$BQ_DATASET`.tdigest_double_merge_k(sketch, 100)) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_to_string(bqutil.datasketches.tdigest_double_merge_k(sketch, 100)) from tdigest_double;
 
 # expected 0.5
-select `$BQ_DATASET`.tdigest_double_get_rank(`$BQ_DATASET`.tdigest_double_merge(sketch), 10) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_get_rank(bqutil.datasketches.tdigest_double_merge(sketch), 10) from tdigest_double;
 
 # expected 10
-select `$BQ_DATASET`.tdigest_double_get_quantile(`$BQ_DATASET`.tdigest_double_merge(sketch), 0.5) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_get_quantile(bqutil.datasketches.tdigest_double_merge(sketch), 0.5) from tdigest_double;
 
 # expected 20
-select `$BQ_DATASET`.tdigest_double_get_total_weight(`$BQ_DATASET`.tdigest_double_merge(sketch)) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_get_total_weight(bqutil.datasketches.tdigest_double_merge(sketch)) from tdigest_double;
 
 # expected 1
-select `$BQ_DATASET`.tdigest_double_get_min_value(`$BQ_DATASET`.tdigest_double_merge(sketch)) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_get_min_value(bqutil.datasketches.tdigest_double_merge(sketch)) from tdigest_double;
 
 # expected 20
-select `$BQ_DATASET`.tdigest_double_get_max_value(`$BQ_DATASET`.tdigest_double_merge(sketch)) from `$BQ_DATASET`.tdigest_double;
+select bqutil.datasketches.tdigest_double_get_max_value(bqutil.datasketches.tdigest_double_merge(sketch)) from tdigest_double;
 
-drop table `$BQ_DATASET`.tdigest_double;
+drop table tdigest_double;
 ```

--- a/theta/README.md
+++ b/theta/README.md
@@ -68,82 +68,82 @@ page for how to contact us.
 ```sql
 
 # using defaults
-create or replace table `$BQ_DATASET`.theta_sketch(sketch bytes);
+create or replace temp table theta_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.theta_sketch
-(select `$BQ_DATASET`.theta_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.theta_sketch
-(select `$BQ_DATASET`.theta_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into theta_sketch
+(select bqutil.datasketches.theta_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into theta_sketch
+(select bqutil.datasketches.theta_sketch_agg_int64(value) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
 # expected about 20000
-select `$BQ_DATASET`.theta_sketch_get_estimate_and_bounds(
-  `$BQ_DATASET`.theta_sketch_agg_union(sketch),
+select bqutil.datasketches.theta_sketch_get_estimate_and_bounds(
+  bqutil.datasketches.theta_sketch_agg_union(sketch),
   2
-) from `$BQ_DATASET`.theta_sketch;
+) from theta_sketch;
 
 # expected estimate about 20000
-select `$BQ_DATASET`.theta_sketch_to_string(
-  `$BQ_DATASET`.theta_sketch_agg_union(sketch)
-) from `$BQ_DATASET`.theta_sketch;
+select bqutil.datasketches.theta_sketch_to_string(
+  bqutil.datasketches.theta_sketch_agg_union(sketch)
+) from theta_sketch;
 
-select `$BQ_DATASET`.theta_sketch_get_theta(
-  `$BQ_DATASET`.theta_sketch_agg_union(sketch)
-) from `$BQ_DATASET`.theta_sketch;
+select bqutil.datasketches.theta_sketch_get_theta(
+  bqutil.datasketches.theta_sketch_agg_union(sketch)
+) from theta_sketch;
 
-select `$BQ_DATASET`.theta_sketch_get_num_retained(
-  `$BQ_DATASET`.theta_sketch_agg_union(sketch)
-) from `$BQ_DATASET`.theta_sketch;
+select bqutil.datasketches.theta_sketch_get_num_retained(
+  bqutil.datasketches.theta_sketch_agg_union(sketch)
+) from theta_sketch;
 
-drop table `$BQ_DATASET`.theta_sketch;
+drop table theta_sketch;
 
 # using full signatures
-create or replace table `$BQ_DATASET`.theta_sketch(sketch bytes);
+create or replace temp table theta_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.theta_sketch
-(select `$BQ_DATASET`.theta_sketch_agg_int64_lgk_seed_p(value, struct<int, int, float64>(14, 111, 0.9)) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.theta_sketch
-(select `$BQ_DATASET`.theta_sketch_agg_int64_lgk_seed_p(value, struct<int, int, float64>(14, 111, 0.9)) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into theta_sketch
+(select bqutil.datasketches.theta_sketch_agg_int64_lgk_seed_p(value, struct<int, int, float64>(14, 111, 0.9)) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into theta_sketch
+(select bqutil.datasketches.theta_sketch_agg_int64_lgk_seed_p(value, struct<int, int, float64>(14, 111, 0.9)) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
 # expected about 20000
-select `$BQ_DATASET`.theta_sketch_get_estimate_and_bounds_seed(
-  `$BQ_DATASET`.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
+select bqutil.datasketches.theta_sketch_get_estimate_and_bounds_seed(
+  bqutil.datasketches.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
   2,
   111
-) from `$BQ_DATASET`.theta_sketch;
+) from theta_sketch;
 
 # expected estimate about 20000
-select `$BQ_DATASET`.theta_sketch_to_string_seed(
-  `$BQ_DATASET`.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
+select bqutil.datasketches.theta_sketch_to_string_seed(
+  bqutil.datasketches.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
   111
-) from `$BQ_DATASET`.theta_sketch;
+) from theta_sketch;
 
-select `$BQ_DATASET`.theta_sketch_get_theta_seed(
-  `$BQ_DATASET`.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
+select bqutil.datasketches.theta_sketch_get_theta_seed(
+  bqutil.datasketches.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
   111
-) from `$BQ_DATASET`.theta_sketch;
+) from theta_sketch;
 
-select `$BQ_DATASET`.theta_sketch_get_num_retained_seed(
-  `$BQ_DATASET`.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
+select bqutil.datasketches.theta_sketch_get_num_retained_seed(
+  bqutil.datasketches.theta_sketch_agg_union_lgk_seed(sketch, struct<int, int>(10, 111)),
   111
-) from `$BQ_DATASET`.theta_sketch;
+) from theta_sketch;
 
-drop table `$BQ_DATASET`.theta_sketch;
+drop table theta_sketch;
 
 # using defaults
 # expected 5
-select `$BQ_DATASET`.theta_sketch_get_estimate(
-  `$BQ_DATASET`.theta_sketch_union(
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.theta_sketch_get_estimate(
+  bqutil.datasketches.theta_sketch_union(
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # full signatures
 # expected 5
-select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
-  `$BQ_DATASET`.theta_sketch_union_lgk_seed(
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.theta_sketch_get_estimate_seed(
+  bqutil.datasketches.theta_sketch_union_lgk_seed(
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
     10,
     111
   ),
@@ -152,19 +152,19 @@ select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
 
 # using defaults
 # expected 1
-select `$BQ_DATASET`.theta_sketch_get_estimate(
-  `$BQ_DATASET`.theta_sketch_intersection(
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.theta_sketch_get_estimate(
+  bqutil.datasketches.theta_sketch_intersection(
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # full signatures
 # expected 1
-select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
-  `$BQ_DATASET`.theta_sketch_intersection_seed(
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.theta_sketch_get_estimate_seed(
+  bqutil.datasketches.theta_sketch_intersection_seed(
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
     111
   ),
   111
@@ -172,19 +172,19 @@ select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
 
 # using defaults
 # expected 2
-select `$BQ_DATASET`.theta_sketch_get_estimate(
-  `$BQ_DATASET`.theta_sketch_a_not_b(
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.theta_sketch_get_estimate(
+  bqutil.datasketches.theta_sketch_a_not_b(
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # full signatures
 # expected 2
-select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
-  `$BQ_DATASET`.theta_sketch_a_not_b_seed(
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.theta_sketch_get_estimate_seed(
+  bqutil.datasketches.theta_sketch_a_not_b_seed(
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
     111
   ),
   111
@@ -192,16 +192,16 @@ select `$BQ_DATASET`.theta_sketch_get_estimate_seed(
 
 # using defaults
 # expected 0.2
-select `$BQ_DATASET`.theta_sketch_jaccard_similarity(
-  (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
-  (select `$BQ_DATASET`.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.theta_sketch_jaccard_similarity(
+  (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["a", "b", "c"]) as str),
+  (select bqutil.datasketches.theta_sketch_agg_string(str) from unnest(["c", "d", "e"]) as str)
 );
 
 # using full signatures
 # expected 0.2
-select `$BQ_DATASET`.theta_sketch_jaccard_similarity_seed(
-  (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
-  (select `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.theta_sketch_jaccard_similarity_seed(
+  (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["a", "b", "c"]) as str),
+  (select bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(str, struct<int, int, float64>(10, 111, 0.999)) from unnest(["c", "d", "e"]) as str),
   111
 );
 ```

--- a/tuple/README.md
+++ b/tuple/README.md
@@ -74,111 +74,110 @@ page for how to contact us.
 ```sql
 
 # using defaults
-create or replace table `$BQ_DATASET`.tuple_sketch(sketch bytes);
+create or replace temp table tuple_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.tuple_sketch
-(select `$BQ_DATASET`.tuple_sketch_int64_from_theta_sketch(`$BQ_DATASET`.theta_sketch_agg_string(cast(value as string)), 1) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.tuple_sketch
-(select `$BQ_DATASET`.tuple_sketch_int64_from_theta_sketch(`$BQ_DATASET`.theta_sketch_agg_string(cast(value as string)), 1) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
+insert into tuple_sketch
+(select bqutil.datasketches.tuple_sketch_int64_from_theta_sketch(bqutil.datasketches.theta_sketch_agg_string(cast(value as string)), 1) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
+insert into tuple_sketch
+(select bqutil.datasketches.tuple_sketch_int64_from_theta_sketch(bqutil.datasketches.theta_sketch_agg_string(cast(value as string)), 1) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
 # expected about 20000
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch)
-) from `$BQ_DATASET`.tuple_sketch;
+select bqutil.datasketches.tuple_sketch_int64_get_estimate(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch)
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_and_bounds(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_and_bounds(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch),
   2
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_sum_estimate_and_bounds(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch),
+select bqutil.datasketches.tuple_sketch_int64_get_sum_estimate_and_bounds(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch),
   2
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
 # expected estimate about 20000
-select `$BQ_DATASET`.tuple_sketch_int64_to_string(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch)
-) from `$BQ_DATASET`.tuple_sketch;
+select bqutil.datasketches.tuple_sketch_int64_to_string(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch)
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_theta(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch)
-) from `$BQ_DATASET`.tuple_sketch;
+select bqutil.datasketches.tuple_sketch_int64_get_theta(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch)
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_num_retained(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union(sketch)
-) from `$BQ_DATASET`.tuple_sketch;
+select bqutil.datasketches.tuple_sketch_int64_get_num_retained(
+  bqutil.datasketches.tuple_sketch_int64_agg_union(sketch)
+) from tuple_sketch;
 
-drop table `$BQ_DATASET`.tuple_sketch;
+drop table tuple_sketch;
 
 # using full signatures
-create or replace table `$BQ_DATASET`.tuple_sketch(sketch bytes);
+create or replace temp table tuple_sketch(sketch bytes);
 
-insert into `$BQ_DATASET`.tuple_sketch
-(select `$BQ_DATASET`.tuple_sketch_int64_from_theta_sketch_seed(
-  `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(cast(value as string), STRUCT<BYTEINT, INT64, FLOAT64>(10, 111, 0.999)),
+insert into tuple_sketch
+(select bqutil.datasketches.tuple_sketch_int64_from_theta_sketch_seed(
+  bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(cast(value as string), STRUCT<BYTEINT, INT64, FLOAT64>(10, 111, 0.999)),
   1,
   111
 ) from unnest(GENERATE_ARRAY(1, 10000, 1)) as value);
-insert into `$BQ_DATASET`.tuple_sketch
-(select `$BQ_DATASET`.tuple_sketch_int64_from_theta_sketch_seed(
-  `$BQ_DATASET`.theta_sketch_agg_string_lgk_seed_p(cast(value as string), STRUCT<BYTEINT, INT64, FLOAT64>(10, 111, 0.999)),
+insert into tuple_sketch
+(select bqutil.datasketches.tuple_sketch_int64_from_theta_sketch_seed(
+  bqutil.datasketches.theta_sketch_agg_string_lgk_seed_p(cast(value as string), STRUCT<BYTEINT, INT64, FLOAT64>(10, 111, 0.999)),
   1,
   111
 ) from unnest(GENERATE_ARRAY(100000, 110000, 1)) as value);
 
 # expected about 20000
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_and_bounds_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_and_bounds_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   2,
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_sum_estimate_and_bounds_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_get_sum_estimate_and_bounds_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   2,
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
 # expected estimate about 20000
-select `$BQ_DATASET`.tuple_sketch_int64_to_string_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_to_string_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_theta_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_get_theta_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-select `$BQ_DATASET`.tuple_sketch_int64_get_num_retained_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
+select bqutil.datasketches.tuple_sketch_int64_get_num_retained_seed(
+  bqutil.datasketches.tuple_sketch_int64_agg_union_lgk_seed_mode(sketch, STRUCT<BYTEINT, INT64, STRING>(10, 111, "NOP")),
   111
-) from `$BQ_DATASET`.tuple_sketch;
+) from tuple_sketch;
 
-drop table `$BQ_DATASET`.tuple_sketch;
-
+drop table tuple_sketch;
 
 # using defaults
 # expected 5
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate(
-  `$BQ_DATASET`.tuple_sketch_int64_union(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_int64(key, 1) from unnest([1, 2, 3]) as key),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_int64(key, 1) from unnest([3, 4, 5]) as key)
+select bqutil.datasketches.tuple_sketch_int64_get_estimate(
+  bqutil.datasketches.tuple_sketch_int64_union(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_int64(key, 1) from unnest([1, 2, 3]) as key),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_int64(key, 1) from unnest([3, 4, 5]) as key)
   )
 );
 
 # using full signatures
 # expected 5
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_union_lgk_seed_mode(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_int64_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest([1, 2, 3]) as key),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_int64_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest([3, 4, 5]) as key),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_seed(
+  bqutil.datasketches.tuple_sketch_int64_union_lgk_seed_mode(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_int64_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest([1, 2, 3]) as key),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_int64_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest([3, 4, 5]) as key),
     10,
     111,
     "MIN"
@@ -188,19 +187,19 @@ select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
 
 # using defaults
 # expected 1
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate(
-  `$BQ_DATASET`.tuple_sketch_int64_intersection(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.tuple_sketch_int64_get_estimate(
+  bqutil.datasketches.tuple_sketch_int64_intersection(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # using full signatures
 # expected 1
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_intersection_seed_mode(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_seed(
+  bqutil.datasketches.tuple_sketch_int64_intersection_seed_mode(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["c", "d", "e"]) as str),
     111,
     "MIN"
   ),
@@ -209,19 +208,19 @@ select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
 
 # using defaults
 # expected 2
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate(
-  `$BQ_DATASET`.tuple_sketch_int64_a_not_b(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.tuple_sketch_int64_get_estimate(
+  bqutil.datasketches.tuple_sketch_int64_a_not_b(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
   )
 );
 
 # using full signatures
 # expected 2
-select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_a_not_b_seed(
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["a", "b", "c"]) as str),
-    (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.tuple_sketch_int64_get_estimate_seed(
+  bqutil.datasketches.tuple_sketch_int64_a_not_b_seed(
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["a", "b", "c"]) as str),
+    (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "MIN")) from unnest(["c", "d", "e"]) as str),
     111
   ),
   111
@@ -229,24 +228,24 @@ select `$BQ_DATASET`.tuple_sketch_int64_get_estimate_seed(
 
 # using defaults
 # expected 0.2
-select `$BQ_DATASET`.tuple_sketch_int64_jaccard_similarity(
-  (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
-  (select `$BQ_DATASET`.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
+select bqutil.datasketches.tuple_sketch_int64_jaccard_similarity(
+  (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["a", "b", "c"]) as str),
+  (select bqutil.datasketches.tuple_sketch_int64_agg_string(str, 1) from unnest(["c", "d", "e"]) as str)
 );
 
 # using full signatures
 # expected 0.2
-select `$BQ_DATASET`.tuple_sketch_int64_jaccard_similarity_seed(
-  (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "NOP")) from unnest(["a", "b", "c"]) as str),
-  (select `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "NOP")) from unnest(["c", "d", "e"]) as str),
+select bqutil.datasketches.tuple_sketch_int64_jaccard_similarity_seed(
+  (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "NOP")) from unnest(["a", "b", "c"]) as str),
+  (select bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(str, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "NOP")) from unnest(["c", "d", "e"]) as str),
   111
 );
 
 # using defaults
 # expected 1 entry
-select `$BQ_DATASET`.tuple_sketch_int64_to_string(
-  `$BQ_DATASET`.tuple_sketch_int64_filter_low_high(
-    `$BQ_DATASET`.tuple_sketch_int64_agg_string(key, 1),
+select bqutil.datasketches.tuple_sketch_int64_to_string(
+  bqutil.datasketches.tuple_sketch_int64_filter_low_high(
+    bqutil.datasketches.tuple_sketch_int64_agg_string(key, 1),
     2,
     2
   )
@@ -254,9 +253,9 @@ select `$BQ_DATASET`.tuple_sketch_int64_to_string(
 
 # using full signatures
 # expected 1 entry
-select `$BQ_DATASET`.tuple_sketch_int64_to_string_seed(
-  `$BQ_DATASET`.tuple_sketch_int64_filter_low_high_seed(
-    `$BQ_DATASET`.tuple_sketch_int64_agg_string_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "SUM")),
+select bqutil.datasketches.tuple_sketch_int64_to_string_seed(
+  bqutil.datasketches.tuple_sketch_int64_filter_low_high_seed(
+    bqutil.datasketches.tuple_sketch_int64_agg_string_lgk_seed_p_mode(key, 1, STRUCT<BYTEINT, INT64, FLOAT64, STRING>(10, 111, 0.999, "SUM")),
     2,
     2,
     111


### PR DESCRIPTION
This change should allow users to copy-paste examples into BQ console and run them