### PR TITLE
Cleanup cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,14 +8,12 @@ steps:
   args:
     - '-c'
     - |
-      apt-get install -y wget unzip
       git clone --branch 4.0.7 --single-branch https://github.com/emscripten-core/emsdk.git
       cd emsdk
       ./emsdk install latest
       ./emsdk activate latest
       source ./emsdk_env.sh
       cd ..
-      git submodule update --init --recursive
       make
       make install
       make test


### PR DESCRIPTION
Remove unnecessary dependency installs since wget & unzip are [now packaged](https://github.com/GoogleCloudPlatform/bigquery-utils/pull/495/commits/abcfd2ac0936c9269343afb5ebbaf834bb47cb70) into gcr.io/bqutil/bq_udf_ci:infrastructure-public-image-bqutil image & remove use of git submodule since [Makefile now explicitly copies](https://github.com/apache/datasketches-bigquery/commit/08b23d117ecd21557cb20babfe85ad777d30a62c) in the submodule contents